### PR TITLE
Fixed parsing of extra whitespace

### DIFF
--- a/tonel/WodenEngine-Core/WDCLineReader.class.st
+++ b/tonel/WodenEngine-Core/WDCLineReader.class.st
@@ -15,7 +15,7 @@ WDCLineReader >> asSpaceTokenReader [
 { #category : #accessing }
 WDCLineReader >> next [
 	^ ByteString streamContents: [ :out |
-		[decoratedStream peek ~= Character cr and: [decoratedStream peek ~= Character lf]] whileTrue: [ 
+		[ decoratedStream atEnd not and: [ decoratedStream peek ~= Character cr and: [decoratedStream peek ~= Character lf]]] whileTrue: [ 
 			out nextPut: decoratedStream next
 		].
 	

--- a/tonel/WodenEngine-Importers/WDIWavefrontMTLImporter.class.st
+++ b/tonel/WodenEngine-Importers/WDIWavefrontMTLImporter.class.st
@@ -91,7 +91,7 @@ WDIWavefrontMTLImporter >> parseLine: line [
 	line ifEmpty: [ ^ self ].
 	line first = $# ifTrue: [ ^ self ].
 	
-	components := line splitOn: ' '.
+	components := line substrings.
 	command := components first.
 	(CommandDictionary at: command ifAbsent: [ ^ self ]) value: self value: components
 ]

--- a/tonel/WodenEngine-Importers/WDIWavefrontObjImporter.class.st
+++ b/tonel/WodenEngine-Importers/WDIWavefrontObjImporter.class.st
@@ -216,7 +216,7 @@ WDIWavefrontObjImporter >> parseLine: line [
 	line ifEmpty: [ ^ self ].
 	line first = $# ifTrue: [ ^ self ].
 	
-	components := line splitOn: ' '.
+	components := line substrings.
 	command := components first.
 	(CommandDictionary at: command ifAbsent: [ ^ self ]) value: self value: components
 ]


### PR DESCRIPTION
* files don't always have line ending as the last byte(s)
* there can be extra whitespace between arguments (e.g. `v 1 2 3` vs `v  1    2       3`)

I don't really see any tests for Woden, so not sure whether I should test this either.

I've discovered the issue when trying to load models from SteamVR.

```smalltalk
model := WDASampleSceneModel new.
scene := model newScene.
camera := model camera.
scene backgroundColor: (Color blue muchLighter asWMVector4F).
camera translateByZ: 0.5.

leftCtrlMesh := scene engine resourceCache loadMesh: 'C:/Program Files (x86)/Steam/steamapps/common/SteamVR/resources/rendermodels/oculus_rifts_controller_left/oculus_rifts_controller_left.obj'.

target := leftCtrl := WDSGSpatialObject new.
leftCtrl renderable: leftCtrlMesh.
leftCtrl color: Color yellow.

scene add: leftCtrl.

target rotateDegreesOnX: 60.

model openWith: WDAFPSSceneView.
```


Also for some reason the entire model is black; I guess because not all commands in MTL/OBJ are supported yet? (`g ...`, `s ...`, `Ni ...`, Tf ...`, etc.)